### PR TITLE
Suggest some improvements to the BP 12.0 URL polyfills

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -23,9 +23,12 @@ class Loader {
 			return;
 		}
 
-		require_once __DIR__ . '/components/activity.php';
 		require_once __DIR__ . '/components/core.php';
 		require_once __DIR__ . '/components/members.php';
+
+		if ( bp_is_active( 'activity' ) ) {
+			require_once __DIR__ . '/components/activity.php';
+		}
 
 		if ( bp_is_active( 'groups' ) ) {
 			require_once __DIR__ . '/components/groups.php';

--- a/src/components/core.php
+++ b/src/components/core.php
@@ -1,12 +1,123 @@
 <?php
 
 /**
- * Polyfills for URL-related functions introduced in BP 12.0 for the Members component.
+ * Polyfills for URL-related functions introduced in BP 12.0 for the Core component.
  */
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+}
+
+if ( ! function_exists( 'bp_rewrites_get_slug' ) ) {
+	/**
+	 * In BP 12.0.0, it's used to get a customized slug.
+	 *
+	 * Here it simply returns the default slug as customizing URL slugs is not supported by BP versions < 12.0.
+	 *
+	 * @param string $component_id The BuddyPress component's ID.
+	 * @param string $rewrite_id   The screen rewrite ID, used to find the custom slugs.
+	 * @param string $default_slug The screen default slug, used as a fallback.
+	 * @return string The slug to use for the screen belonging to the requested component.
+	 */
+	function bp_rewrites_get_slug( $component_id = '', $rewrite_id = '', $default_slug = '' ) {
+		return $default_slug;
+	}
+}
+
+if ( ! function_exists( 'bp_rewrites_get_url' ) ) {
+	/**
+	 * Gets a BuddyPress URL.
+	 *
+	 * @param array $args {
+	 *      Optional. An array of arguments.
+	 *
+	 *      @type string $component_id                The BuddyPress component ID. Defaults ''.
+	 *      @type string $directory_type              Whether it's an object type URL. Defaults ''.
+	 *                                                Accepts '' (no object type), 'members' or 'groups'.
+	 *      @type string $single_item                 The BuddyPress single item's URL chunk. Defaults ''.
+	 *                                                Eg: the member's user nicename for Members or the group's slug for Groups.
+	 *      @type string $single_item_component       The BuddyPress single item's component URL chunk. Defaults ''.
+	 *                                                Eg: the member's Activity page.
+	 *      @type string $single_item_action          The BuddyPress single item's action URL chunk. Defaults ''.
+	 *                                                Eg: the member's Activity mentions page.
+	 *      @type array $single_item_action_variables The list of BuddyPress single item's action variable URL chunks. Defaults [].
+	 * }
+	 * @return string The BuddyPress URL.
+	 */
+	function bp_rewrites_get_url( $args = array() ) {
+		$url = trailingslashit( bp_get_root_domain() );
+
+		$r = bp_parse_args(
+			$args,
+			array(
+				'component_id'                 => '',
+				'directory_type'               => '',
+				'single_item'                  => '',
+				'single_item_component'        => '',
+				'single_item_action'           => '',
+				'single_item_action_variables' => array(),
+			)
+		);
+
+		$chunks = array();
+
+		if ( $r['component_id'] && bp_is_active( $r['component_id'] ) ) {
+			$bp = buddypress();
+
+			if ( isset( $bp->pages->{ $r['component_id'] }->id ) ) {
+				$url = get_permalink( $bp->pages->{ $r['component_id'] }->id );
+
+				if ( $r['single_item'] ) {
+					$chunks[] = $r['single_item'];
+
+					if ( 'members' === $r['component_id'] && bp_core_enable_root_profiles() ) {
+						$url = trailingslashit( bp_get_root_domain() );
+					}
+
+					if ( $r['single_item_component'] && 'members' === $r['component_id'] ) {
+						$chunks[] = $r['single_item_component'];
+					}
+
+					if ( $r['single_item_action'] ) {
+						$chunks[] = $r['single_item_action'];
+					}
+
+					if ( $r['single_item_action_variables'] && is_array( $r['single_item_action_variables'] ) ) {
+						$chunks = array_merge( $chunks, $r['single_item_action_variables'] );
+					}
+
+				} elseif ( $r['directory_type'] ) {
+					if ( 'members' === $r['component_id'] ) {
+						$chunks[] = bp_get_members_member_type_base();
+					} elseif ( 'groups' === $r['component_id'] ) {
+						$chunks[] = bp_get_groups_group_type_base();
+					}
+
+					$chunks[] = $r['directory_type'];
+
+				} elseif ( isset( $r['member_register'] ) && 'members' === $r['component_id'] ) {
+					return bp_get_signup_page();
+
+				} elseif ( isset( $r['member_activate'] ) && 'members' === $r['component_id'] ) {
+					return bp_get_activation_page();
+
+				} elseif ( isset( $r['create_single_item'] ) ) {
+					$chunks[] = 'create';
+
+					if ( isset( $r['create_single_item_variables'] ) && is_array( $r['create_single_item_variables'] ) ) {
+						$chunks = array_merge( $chunks, $r['create_single_item_variables'] );
+					}
+				}
+			}
+		}
+
+		if ( $chunks ) {
+			$url .= join( '/', $chunks ) . '/';
+		}
+
+		return $url;
+	}
 }
 
 if ( ! function_exists( 'bp_get_root_url' ) ) {

--- a/src/components/groups.php
+++ b/src/components/groups.php
@@ -61,15 +61,13 @@ if ( ! function_exists( 'bp_group_manage_url' ) ) :
 /**
  * Outputs the requested group's manage URL.
  *
- * @param int|BP_Groups_Group $group       The group ID or the group object.
- * @param array               $path_chunks {
- *     An array of path chunks to append to the URL. Optional.
- *
- *     @type array $single_item_action_variables An array of additional URL chunks.
- * }
+ * @param int|BP_Groups_Group $group  The group ID or the group object.
+ * @param array               $chunks A list of default BP Slugs to append.
  * @return void
  */
-function bp_group_manage_url( $group = 0, $path_chunks = array() ) {
+function bp_group_manage_url( $group = 0, $chunks = array() ) {
+	$path_chunks = bp_groups_get_path_chunks( $chunks, 'manage' );
+
 	echo esc_url( bp_get_group_manage_url( $group, $path_chunks ) );
 }
 endif;
@@ -114,8 +112,12 @@ function bp_groups_get_path_chunks( $chunks = array(), $context = 'read' ) {
 	$path_chunks = array();
 
 	if ( 'manage' === $context ) {
-		$path_chunks['single_item_action']           = 'admin';
 		$path_chunks['single_item_action_variables'] = $chunks;
+
+	} elseif ( 'create' === $context && $chunks ) {
+		$path_chunks['create_single_item_variables'] = array( 'step' );
+		$path_chunks['create_single_item_variables'] = array_merge( $path_chunks['create_single_item_variables'], $chunks );
+
 	} else {
 		$single_item_action = array_shift( $chunks );
 		if ( $single_item_action ) {
@@ -170,6 +172,10 @@ function bp_get_groups_directory_url( $path_chunks = array() ) {
 
 	if ( ! empty( $path_chunks['create_single_item'] ) ) {
 		$directory_url = trailingslashit( $directory_url . 'create' );
+
+		if ( ! empty( $path_chunks['create_single_item_variables'] ) && is_array( $path_chunks['create_single_item_variables'] ) ) {
+			$directory_url .= join( '/', $path_chunks['create_single_item_variables'] ) . '/';
+		}
 	}
 
 	return $directory_url;
@@ -184,14 +190,12 @@ if ( ! function_exists( 'bp_groups_get_create_url' ) ) :
  * @return string The group create URL.
  */
 function bp_groups_get_create_url( $action_variables = array() ) {
-	$path_chunks = array();
+	$path_chunks = array(
+		'create_single_item' => 1,
+	);
 
 	if ( is_array( $action_variables ) && $action_variables ) {
-		$path_chunks = bp_groups_get_path_chunks( $action_variables, 'create' );
-	} else {
-		$path_chunks = array(
-			'create_single_item' => 1,
-		);
+		$path_chunks = array_merge( $path_chunks, bp_groups_get_path_chunks( $action_variables, 'create' ) );
 	}
 
 	return bp_get_groups_directory_url( $path_chunks );

--- a/src/components/members.php
+++ b/src/components/members.php
@@ -8,6 +8,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'bp_members_get_user_slug' ) ) {
+	/**
+	 * Get a member's slug.
+	 *
+	 * @param integer $user_id The User ID.
+	 * @return string The member slug.
+	 */
+	function bp_members_get_user_slug( $user_id = 0 ) {
+		return bp_core_get_username( $user_id );
+	}
+}
+
 if ( ! function_exists( 'bp_members_get_user_url' ) ) :
 /**
  * Gets the URL of a user.


### PR DESCRIPTION
- As `bp_group_manage_url()` can be used inside a template file, I thought it was best to make it possible to send a list of slugs rather than an associative array. It is explaining why `bp_groups_get_path_chunks()` is looking a bit weird.
- In Core URL polyfills, I suggest to include some other functions just in case these would be directly used